### PR TITLE
Get kubeconfig path from KUBECONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ Pod awesome-app-web-4212725599-pvjsm has detected
 [awesome-app-web-4212725599-zei9h]  | Migrating to CreatePosts (20160218082522)
 ```
 
+### kubeconfig file
+
+As default, `k8stail` use `~/.kube/config`. You can specify another path by `KUBECONFIG` environment variable or `-kubeconfig` option. `-kubeconfig` option always overrides `KUBECONFIG` environment variable.
+
+```bash
+$ KUBECONFIG=/path/to/kubeconfig k8stail
+# or
+$ k8stail -kubeconfig=/path/to/kubeconfig
+```
+
 ### Options
 
 |Option|Description|Required|Default|

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Pod awesome-app-web-4212725599-pvjsm has detected
 
 ### kubeconfig file
 
-As default, `k8stail` use `~/.kube/config`. You can specify another path by `KUBECONFIG` environment variable or `-kubeconfig` option. `-kubeconfig` option always overrides `KUBECONFIG` environment variable.
+`k8stail` use `~/.kube/config` as default. You can specify another path by `KUBECONFIG` environment variable or `-kubeconfig` option. `-kubeconfig` option always overrides `KUBECONFIG` environment variable.
 
 ```bash
 $ KUBECONFIG=/path/to/kubeconfig k8stail

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Pod awesome-app-web-4212725599-pvjsm has detected
 
 ### kubeconfig file
 
-`k8stail` use `~/.kube/config` as default. You can specify another path by `KUBECONFIG` environment variable or `-kubeconfig` option. `-kubeconfig` option always overrides `KUBECONFIG` environment variable.
+`k8stail` uses `~/.kube/config` as default. You can specify another path by `KUBECONFIG` environment variable or `-kubeconfig` option. `-kubeconfig` option always overrides `KUBECONFIG` environment variable.
 
 ```bash
 $ KUBECONFIG=/path/to/kubeconfig k8stail

--- a/main.go
+++ b/main.go
@@ -34,12 +34,20 @@ func main() {
 		flags.PrintDefaults()
 	}
 
-	flags.StringVar(&kubeconfig, "kubeconfig", clientcmd.RecommendedHomeFile, fmt.Sprintf("Path of kubeconfig (Default: %s)", clientcmd.RecommendedHomeFile))
+	flags.StringVar(&kubeconfig, "kubeconfig", "", fmt.Sprintf("Path of kubeconfig (Default: %s)", clientcmd.RecommendedHomeFile))
 	flags.StringVar(&labels, "labels", "", "Label filter query (Default: \"\")")
 	flags.StringVar(&namespace, "namespace", v1.NamespaceDefault, fmt.Sprintf("Kubernetes namespace (Default: %s)", v1.NamespaceDefault))
 	flags.BoolVar(&timestamps, "timestamps", false, "Include timestamps on each line (default: false)")
 	flags.BoolVar(&version, "version", false, "Print version")
 	flags.BoolVar(&version, "v", false, "Print version")
+
+	if kubeconfig == "" {
+		if os.Getenv("KUBECONFIG") != "" {
+			kubeconfig = os.Getenv("KUBECONFIG")
+		} else {
+			kubeconfig = clientcmd.RecommendedHomeFile
+		}
+	}
 
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, err)


### PR DESCRIPTION
Close #3 

## WHY

`kubectl` accepts both `-kubeconfig` option and `KUBECONFIG` environment variable to specify the path of kubeconfig file.

## WHAT

Get kubeconfig path from `KUBECONFIG` environment variable.