### PR TITLE
Prepare Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*
+!bin/k8stail

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ deploy:
     skip_cleanup: true
     script: make ci-docker-release
     on:
-      all_branches: true
-      # branch: master
+      branch: master
       go: '1.7'
   - provider: script
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+services:
+  - docker
 language: go
 go:
   - '1.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ deploy:
     skip_cleanup: true
     script: make ci-docker-release
     on:
-      branch: master
+      # branch: master
+      all_branches: true
       go: '1.7'
   - provider: script
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ deploy:
     skip_cleanup: true
     script: make ci-docker-release
     on:
-      branch: master
+      all_branches: true
+      # branch: master
       go: '1.7'
   - provider: script
     skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 script:
   - make test
 before_deploy:
+  - GOOS=linux GOARCH=amd64 make
   - make cross-build
   - make dist
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script:
   - make test
 before_deploy:
-  - GOOS=linux GOARCH=amd64 make
+  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 make
   - make cross-build
   - make dist
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,23 @@ before_deploy:
   - make cross-build
   - make dist
 deploy:
-  provider: releases
-  skip_cleanup: true
-  api_key: $GITHUB_TOKEN
-  file_glob: true
-  file: 'dist/*.{tar.gz,zip}'
-  on:
-    tags: true
-    go: '1.7'
+  - provider: releases
+    skip_cleanup: true
+    api_key: $GITHUB_TOKEN
+    file_glob: true
+    file: 'dist/*.{tar.gz,zip}'
+    on:
+      tags: true
+      go: '1.7'
+  - provider: script
+    skip_cleanup: true
+    script: make ci-docker-release
+    on:
+      branch: master
+      go: '1.7'
+  - provider: script
+    skip_cleanup: true
+    script: DOCKER_IMAGE_TAG=$TRAVIS_TAG make ci-docker-release
+    on:
+      tags: true
+      go: '1.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,7 @@ deploy:
     skip_cleanup: true
     script: make ci-docker-release
     on:
-      # branch: master
-      all_branches: true
+      branch: master
       go: '1.7'
   - provider: script
     skip_cleanup: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM alpine:3.4
 
+ENV GLIBC_VERSION 2.23-r3
+
 RUN apk add --no-cache --update ca-certificates
+
+RUN apk add --no-cache --update wget \
+    && wget -qO /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
+    && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk \
+    && apk add glibc-$GLIBC_VERSION.apk \
+    && rm glibc-$GLIBC_VERSION.apk \
+    && apk del wget
 
 COPY bin/k8stail /k8stail
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.4
+
+RUN apk add --no-cache --update ca-certificates
+
+COPY bin/k8stail /k8stail
+
+ENTRYPOINT ["/k8stail"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,6 @@ ENV GLIBC_VERSION 2.23-r3
 
 RUN apk add --no-cache --update ca-certificates
 
-RUN apk add --no-cache --update wget \
-    && wget -qO /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub \
-    && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/$GLIBC_VERSION/glibc-$GLIBC_VERSION.apk \
-    && apk add glibc-$GLIBC_VERSION.apk \
-    && rm glibc-$GLIBC_VERSION.apk \
-    && apk del wget
-
 COPY bin/k8stail /k8stail
 
 ENTRYPOINT ["/k8stail"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.4
 
-ENV GLIBC_VERSION 2.23-r3
-
 RUN apk add --no-cache --update ca-certificates
 
 COPY bin/k8stail /k8stail

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,20 @@ LDFLAGS   := -ldflags="-s -w -X \"main.Version=$(VERSION)\" -X \"main.Revision=$
 
 DIST_DIRS := find * -type d -exec
 
+DOCKER_REPOSITORY := quay.io
+DOCKER_IMAGE_NAME := $(DOCKER_REPOSITORY)/dtan4/k8stail
+DOCKER_IMAGE_TAG  ?= latest
+DOCKER_IMAGE      := $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
+
 .DEFAULT_GOAL := bin/$(NAME)
 
 bin/$(NAME): $(SRCS)
 	go build $(LDFLAGS) -o bin/$(NAME)
+
+.PHONY: ci-docker-release
+ci-docker-release: docker-build
+	@docker login -e="$(DOCKER_QUAY_EMAIL)" -u="$(DOCKER_QUAY_USERNAME)" -p="$(DOCKER_QUAY_PASSWORD)" $(DOCKER_REPOSITORY)
+	docker push $(DOCKER_IMAGE)
 
 .PHONY: clean
 clean:
@@ -37,6 +47,14 @@ dist:
 	$(DIST_DIRS) tar -zcf $(NAME)-$(VERSION)-{}.tar.gz {} \; && \
 	$(DIST_DIRS) zip -r $(NAME)-$(VERSION)-{}.zip {} \; && \
 	cd ..
+
+.PHONY: docker-build
+docker-build:
+ifeq ($(findstring ELF 64-bit LSB,$(shell file bin/$(NAME) 2> /dev/null)),)
+	@echo "bin/$(NAME) is not a binary of Linux 64bit binary."
+	@exit 1
+endif
+	docker build -t $(DOCKER_IMAGE) .
 
 .PHONY: glide
 glide:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # k8stail
 
 [![Build Status](https://travis-ci.org/dtan4/k8stail.svg?branch=master)](https://travis-ci.org/dtan4/k8stail)
+[![Docker Repository on Quay](https://quay.io/repository/dtan4/k8stail/status "Docker Repository on Quay")](https://quay.io/repository/dtan4/k8stail)
 
 `tail -f` experience for Kubernetes Pods
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ As you know, `kubectl logs` can stream only ONE pod at the same time. `k8stail` 
   + [Using Homebrew (OS X only)](#using-homebrew-os-x-only)
   + [Precompiled binary](#precompiled-binary)
   + [From source](#from-source)
+  + [Run in a Docker container](#run-in-a-docker-container)
 * [Usage](#usage)
   + [kubeconfig file](#kubeconfig-file)
   + [Options](#options)
@@ -44,6 +45,20 @@ $ go get -d github.com/dtan4/k8stail
 $ cd $GOPATH/src/github.com/dtan4/k8stail
 $ make deps
 $ make install
+```
+
+### Run in a Docker container
+
+Docker image is available at [quay.io/dtan4/k8stail](https://quay.io/repository/dtan4/k8stail).
+
+```bash
+# -t is required to colorize logs
+$ docker run \
+    --rm \
+    -t \
+    -v $HOME/.kube/config:/.kube/config \
+    quay.io/dtan4/k8stail:latest \
+      -kubeconfig=/.kube/config
 ```
 
 ## Usage


### PR DESCRIPTION
## WHY

Sometimes we would like to run k8stail in isolated environment.

## WHAT

Prepare Docker image of k8stail. Build and push image from Travis CI.

Image repository is https://quay.io/repository/dtan4/k8stail.