### PR TITLE
Disable cgo while cross-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ clean:
 cross-build: deps
 	for os in darwin linux windows; do \
 		for arch in amd64 386; do \
-			GOOS=$$os GOARCH=$$arch go build $(LDFLAGS) -o dist/$$os-$$arch/$(NAME); \
+			GOOS=$$os GOARCH=$$arch CGO_ENABLED=0 go build $(LDFLAGS) -o dist/$$os-$$arch/$(NAME); \
 		done; \
 	done
 


### PR DESCRIPTION
## WHY

From Go 1.4, application with netgo are built as dynamically-linked binary in default so that netgo requires cgo. This behavior lacks binary portability.

## WHAT

Build statically-linked binary by disabling cgo.

## REF

- [go 1.4 and static linking - Google グループ](https://groups.google.com/forum/#!topic/golang-nuts/S2WDcm47bhA)
- [cmd/go: add test for build -a -tags netgo -installsuffix netgo in test.bash · Issue #9369 · golang/go](https://github.com/golang/go/issues/9369)