### PR TITLE
Add --no-halt flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ $ k8stail --kubeconfig=/path/to/kubeconfig
 |`--kubeconfig=KUBECONFIG`|Path of kubeconfig||`~/.kube/config`|
 |`--labels=LABELS`|Label filter query (e.g. `app=APP,role=ROLE`)|||
 |`--namespace=NAMESPACE`|Kubernetes namespace||`default`|
+|`--no-halt`|Does not halt k8stail even if there is no pod||`false`|
 |`--timestamps`|Include timestamps on each line||`false`|
 |`-h`, `-help`|Print command line usage|||
 |`-v`, `-version`|Print version|||

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 		kubeconfig string
 		labels     string
 		namespace  string
+		noHalt     bool
 		timestamps bool
 		version    bool
 	)
@@ -43,6 +44,7 @@ func main() {
 	flags.StringVar(&kubeconfig, "kubeconfig", "", "Path of kubeconfig")
 	flags.StringVar(&labels, "labels", "", "Label filter query")
 	flags.StringVar(&namespace, "namespace", v1.NamespaceDefault, "Kubernetes namespace")
+	flags.BoolVar(&noHalt, "no-halt", false, "Does not halt k8stail even if there is no pod")
 	flags.BoolVar(&timestamps, "timestamps", false, "Include timestamps on each line")
 	flags.BoolVarP(&version, "version", "v", false, "Print version")
 
@@ -149,7 +151,7 @@ func main() {
 			}
 		}
 
-		if runningContainers.Length() == 0 {
+		if runningContainers.Length() == 0 && !noHalt {
 			break
 		}
 	}


### PR DESCRIPTION
## WHY

If there is no running Pod right after invoked `k8stail`, k8stail shut down immediately.
This behavior is inconvenient to watch non-long-running job, like ScheduledJob (CronJob).

## WHAT

Add `--no-halt` flag not to shut down immediately even if there is no running Pod.