### PR TITLE
Use default namespace set in kubecfg

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	flags.StringVar(&context, "context", "", "Kubernetes context")
 	flags.StringVar(&kubeconfig, "kubeconfig", "", "Path of kubeconfig")
 	flags.StringVar(&labels, "labels", "", "Label filter query")
-	flags.StringVar(&namespace, "namespace", v1.NamespaceDefault, "Kubernetes namespace")
+	flags.StringVar(&namespace, "namespace", "", "Kubernetes namespace")
 	flags.BoolVar(&noHalt, "no-halt", false, "Does not halt k8stail even if there is no pod")
 	flags.BoolVar(&timestamps, "timestamps", false, "Include timestamps on each line")
 	flags.BoolVarP(&version, "version", "v", false, "Print version")
@@ -88,6 +88,14 @@ func main() {
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
+	}
+
+	if namespace == "" {
+		if rawConfig.Contexts[rawConfig.CurrentContext].Namespace == "" {
+			namespace = v1.NamespaceDefault
+		} else {
+			namespace = rawConfig.Contexts[rawConfig.CurrentContext].Namespace
+		}
 	}
 
 	fmt.Printf("%s %s\n", bold("Context:  "), rawConfig.CurrentContext)


### PR DESCRIPTION
Close #15

kubecfg context can have default namespace instead of `default`. Now k8stail reads this value and use by default.

```bash
$ kubectl config get-contexts
CURRENT   NAME                                 CLUSTER                              AUTHINFO                             NAMESPACE
*         qa.cluster.examplesapp.com           qa.cluster.examplesapp.com           qa.cluster.examplesapp.com           sample-rails

$ bin/k8stail
Context:   qa.cluster.examplesapp.com
Namespace: sample-rails
Labels:
Press Ctrl-C to exit.
----------
^C
```