### PR TITLE
Add more short flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,10 +42,10 @@ func main() {
 
 	flags.StringVar(&context, "context", "", "Kubernetes context")
 	flags.StringVar(&kubeconfig, "kubeconfig", "", "Path of kubeconfig")
-	flags.StringVar(&labels, "labels", "", "Label filter query")
-	flags.StringVar(&namespace, "namespace", "", "Kubernetes namespace")
+	flags.StringVarP(&labels, "labels", "l", "", "Label filter query")
+	flags.StringVarP(&namespace, "namespace", "n", "", "Kubernetes namespace")
 	flags.BoolVar(&noHalt, "no-halt", false, "Does not halt k8stail even if there is no pod")
-	flags.BoolVar(&timestamps, "timestamps", false, "Include timestamps on each line")
+	flags.BoolVarP(&timestamps, "timestamps", "t", false, "Include timestamps on each line")
 	flags.BoolVarP(&version, "version", "v", false, "Print version")
 
 	if kubeconfig == "" {


### PR DESCRIPTION
Adds short flags for `--namespace` (`-n`), `--timestamps` (`-t`) and `--labels` (`-l`) for convenience, and also to mirror `kubectl` usage.