### PR TITLE
Print selected context correctly

### DIFF
--- a/main.go
+++ b/main.go
@@ -85,11 +85,19 @@ func main() {
 		os.Exit(1)
 	}
 
+	var currentContext string
+
+	if kubeContext == "" {
+		currentContext = rawConfig.CurrentContext
+	} else {
+		currentContext = kubeContext
+	}
+
 	if namespace == "" {
-		if rawConfig.Contexts[rawConfig.CurrentContext].Namespace == "" {
+		if rawConfig.Contexts[currentContext].Namespace == "" {
 			namespace = v1.NamespaceDefault
 		} else {
-			namespace = rawConfig.Contexts[rawConfig.CurrentContext].Namespace
+			namespace = rawConfig.Contexts[currentContext].Namespace
 		}
 	}
 
@@ -97,7 +105,7 @@ func main() {
 	signal.Notify(sigCh, os.Interrupt)
 
 	logger := NewLogger()
-	logger.PrintHeader(rawConfig.CurrentContext, namespace, labels)
+	logger.PrintHeader(currentContext, namespace, labels)
 
 	watcher, err := clientset.Core().Pods(namespace).Watch(v1.ListOptions{
 		LabelSelector: labels,


### PR DESCRIPTION
## WHY

Whatever user selects `--context`, output header always shows current context set in kubeconfig.
Pod logs are streamed using correct context.

## WHAT

Print correct context in header