### PR TITLE
Allow multiple kubernetes configs

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	flag "github.com/spf13/pflag"
@@ -74,8 +75,10 @@ func main() {
 		}()
 	}
 
+	kubeConfigPaths := strings.Split(kubeconfig, ":")
+
 	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		&clientcmd.ClientConfigLoadingRules{Precedence: kubeConfigPaths},
 		&clientcmd.ConfigOverrides{CurrentContext: kubeContext})
 
 	config, err := clientConfig.ClientConfig()


### PR DESCRIPTION
In fact `KUBECONFIG` supports multiple locations joined with colon. 
Add a support for that here as well.